### PR TITLE
Rate limit emails

### DIFF
--- a/controllers/email.js
+++ b/controllers/email.js
@@ -19,7 +19,9 @@ var transporter = nodemailer.createTransport({
     user: config.opt.email.user,
     pass: config.opt.email.pass
   },
-  pool: true
+  pool: true,
+  rateDelta: 1000, // ms
+  rateLimit: 12
 });
 
 exports.welcome = function (user, email) {


### PR DESCRIPTION
AWS SES limits us to 14 emails per second. Limit sending rate accordingly.